### PR TITLE
Fix copying _ctru/ into Modules on macOS

### DIFF
--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -103,7 +103,7 @@ configurePython: preparePython
 preparePython: $(PYDIR)
 	$(SED) -i -e 's/\*\-\*\-linux\*)/\*\-\*\-linux\*\|arm\-none\-eabi)/g' $(PYDIR)/configure
 	cp $(PATCH_DIR)/config.site $(PYDIR)/
-	cp -r $(PATCH_DIR)/_ctru/ $(PYDIR)/Modules/
+	cp -r $(PATCH_DIR)/_ctru $(PYDIR)/Modules/
 	cp $(PATCH_DIR)/Setup.dist $(PYDIR)/Modules/
 
 $(PYDIR):


### PR DESCRIPTION
A difference in how cp works on macOS means this was copying
_ctru/_ctrumodule.c directly into Modules, instead of copying the
directory, causing a build error.