### PR TITLE
Fix CI build again

### DIFF
--- a/.ci/docker.sh
+++ b/.ci/docker.sh
@@ -3,6 +3,6 @@
 source /etc/profile.d/devkit-env.sh
 
 apt-get update
-apt-get install -y patch
+apt-get install -y patch zip
 
 make -C 3DS.py

--- a/.ci/docker.sh
+++ b/.ci/docker.sh
@@ -2,6 +2,7 @@
 
 source /etc/profile.d/devkit-env.sh
 
+apt-get update
 apt-get install -y patch
 
 make -C 3DS.py


### PR DESCRIPTION
apt-get install can fail if apt-get update is not executed,
because packages can get updated remotely and local info be outdated,
trying to get older package versions no longer up.